### PR TITLE
change position of alert and add backspace to browse back

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,6 @@ DEPENDENCIES
   font-awesome-sass (~> 5.6.1)
   jbuilder (~> 2.0)
   listen (~> 3.0.5)
-  nokogiri
   pg (~> 0.21)
   pry-byebug
   pry-rails

--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -1,6 +1,6 @@
 .alert {
   position: fixed;
-  bottom: 16px;
+  top: 110px;
   right: 16px;
   z-index: 1000;
 }

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,4 @@
 class PagesController < ApplicationController
-  skip_before_action :authenticate_user!, only: :home
-
-  def home
+def home
   end
 end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -1,1 +1,13 @@
 import "bootstrap";
+
+const body = document.querySelector('body');
+
+const backWithBackspace = (event) => {
+  event.preventDefault();
+  console.log(event.keyCode)
+  if (event.keyCode === 8) {
+    window.history.back();
+  }
+}
+
+body.addEventListener('keyup', backWithBackspace);


### PR DESCRIPTION
- [x] Moved the flash alert to the top of the page.

- [x] Added an event listener that navigates back to the previous page when you press the backspace key on the keyboard